### PR TITLE
Feature fix gcc13 warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ __pycache__/
 # Eclipse
 #--------------------- 
 /.project
-/.pydevprojec
+/.pydevproject
 /.cproject
 /.settings
 

--- a/EleCfitsioWrapper/EleCfitsioWrapper/impl/TypeWrapper.hpp
+++ b/EleCfitsioWrapper/EleCfitsioWrapper/impl/TypeWrapper.hpp
@@ -6,6 +6,8 @@
 
 #include "EleCfitsioWrapper/TypeWrapper.h"
 
+#include <cstdint>
+
 namespace Euclid {
 namespace Cfitsio {
 

--- a/EleFitsData/EleFitsData/Column.h
+++ b/EleFitsData/EleFitsData/Column.h
@@ -279,7 +279,7 @@ PtrColumn<T, std::decay_t<TInfo>::Dim> make_column(TInfo&& info, long row_count,
  * @deprecated
  */
 template <typename... TArgs>
-[[deprecated]] auto makeColumn(TArgs&&... args) {
+[[deprecated("Use make_column")]] auto makeColumn(TArgs&&... args) {
   return make_column(std::forward<TArgs>(args)...);
 }
 

--- a/EleFitsData/EleFitsData/ColumnInfo.h
+++ b/EleFitsData/EleFitsData/ColumnInfo.h
@@ -255,7 +255,7 @@ ColumnInfo<T> make_column_info(const std::string& name, const std::string& unit 
  * @deprecated
  */
 template <typename T, typename... TArgs>
-[[deprecated]] auto makeColumnInfo(TArgs&&... args) {
+[[deprecated("Use make_column_info")]] auto makeColumnInfo(TArgs&&... args) {
   return make_column_info<T>(std::forward<TArgs>(args)...);
 }
 

--- a/EleFitsData/EleFitsData/ColumnInfo.h
+++ b/EleFitsData/EleFitsData/ColumnInfo.h
@@ -8,6 +8,7 @@
 #include "EleFitsData/Position.h"
 
 #include <complex>
+#include <cstdint>
 #include <string>
 
 namespace Euclid {

--- a/EleFitsData/tests/src/DataUtils_test.cpp
+++ b/EleFitsData/tests/src/DataUtils_test.cpp
@@ -5,6 +5,8 @@
 #include "EleFitsData/DataUtils.h"
 
 #include <boost/test/unit_test.hpp>
+#include <climits>
+#include <cstdint>
 
 using namespace Euclid::Fits;
 
@@ -163,7 +165,7 @@ BOOST_AUTO_TEST_CASE(bitpix_bzero_test) {
   BOOST_TEST(bitpix<std::int64_t>() == 64);
   BOOST_TEST(offset<std::int64_t>() == 0);
   BOOST_TEST(bitpix<std::uint64_t>() == 64);
-  BOOST_TEST((offset<std::uint64_t>() == -9223372036854775808));
+  BOOST_TEST((offset<std::uint64_t>() == LONG_LONG_MIN));
   BOOST_TEST(bitpix<float>() == -32);
   BOOST_TEST(offset<float>() == 0);
   BOOST_TEST(bitpix<double>() == -64);

--- a/EleFitsData/tests/src/DataUtils_test.cpp
+++ b/EleFitsData/tests/src/DataUtils_test.cpp
@@ -5,8 +5,8 @@
 #include "EleFitsData/DataUtils.h"
 
 #include <boost/test/unit_test.hpp>
-#include <climits>
 #include <cstdint>
+#include <limits>
 
 using namespace Euclid::Fits;
 
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(bitpix_bzero_test) {
   BOOST_TEST(bitpix<std::int64_t>() == 64);
   BOOST_TEST(offset<std::int64_t>() == 0);
   BOOST_TEST(bitpix<std::uint64_t>() == 64);
-  BOOST_TEST((offset<std::uint64_t>() == LONG_LONG_MIN));
+  BOOST_TEST((offset<std::uint64_t>() == std::numeric_limits<std::int64_t>::min()));
   BOOST_TEST(bitpix<float>() == -32);
   BOOST_TEST(offset<float>() == 0);
   BOOST_TEST(bitpix<double>() == -64);

--- a/EleFitsData/tests/src/DataUtils_test.cpp
+++ b/EleFitsData/tests/src/DataUtils_test.cpp
@@ -157,11 +157,11 @@ BOOST_AUTO_TEST_CASE(bitpix_bzero_test) {
   BOOST_TEST(bitpix<std::int16_t>() == 16);
   BOOST_TEST(offset<std::int16_t>() == 0);
   BOOST_TEST(bitpix<std::uint16_t>() == 16);
-  BOOST_TEST(offset<std::uint16_t>() == -32768);
+  BOOST_TEST(offset<std::uint16_t>() == std::numeric_limits<std::int16_t>::min());
   BOOST_TEST(bitpix<std::int32_t>() == 32);
   BOOST_TEST(offset<std::int32_t>() == 0);
   BOOST_TEST(bitpix<std::uint32_t>() == 32);
-  BOOST_TEST(offset<std::uint32_t>() == -2147483648);
+  BOOST_TEST(offset<std::uint32_t>() == std::numeric_limits<std::int32_t>::min());
   BOOST_TEST(bitpix<std::int64_t>() == 64);
   BOOST_TEST(offset<std::int64_t>() == 0);
   BOOST_TEST(bitpix<std::uint64_t>() == 64);


### PR DESCRIPTION
- Fix gcc warnings: essentially missing header files due to the include tree reorganization of GCC 13
- Add deprecation messages